### PR TITLE
docs: Add configurable Ansible inventory group documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ UNIFI_HOST=192.168.1.1
 # =============================================================================
 # Pi-hole DNS Configuration
 # =============================================================================
+# Ansible inventory group name for Pi-hole servers (default: PiHole)
+# Change this if you use a different group name in your ansible_hosts.yml
+# PIHOLE_ANSIBLE_GROUP=PiHole
+
 # Pi-hole API Keys (Application Passwords from Settings > API)
 # Format: PIHOLE_API_KEY_{NAME} where {NAME} is your identifier
 PIHOLE_API_KEY_SERVER1=your-first-pihole-api-key
@@ -75,6 +79,11 @@ LITELLM_PORT=4000
 # =============================================================================
 # Docker/Podman Container Management
 # =============================================================================
+# Ansible inventory group names (used when loading from Ansible inventory)
+# Change these if you use different group names in your ansible_hosts.yml
+# DOCKER_ANSIBLE_GROUP=docker_hosts
+# PODMAN_ANSIBLE_GROUP=podman_hosts
+
 # Docker endpoints (format: host:port)
 # Format: DOCKER_{NAME}_ENDPOINT where {NAME} is your identifier
 DOCKER_SERVER1_ENDPOINT=192.168.1.100:2375

--- a/README.md
+++ b/README.md
@@ -528,6 +528,11 @@ Unified server mode (namespaced):
 
 ```bash
 ANSIBLE_INVENTORY_PATH=/path/to/ansible_hosts.yml
+
+# Ansible inventory group names (default: docker_hosts, podman_hosts)
+# Change these if you use different group names in your ansible_hosts.yml
+DOCKER_ANSIBLE_GROUP=docker_hosts
+PODMAN_ANSIBLE_GROUP=podman_hosts
 ```
 
 **Option 2: Using Environment Variables**
@@ -665,6 +670,11 @@ Monitor Pi-hole DNS statistics and status.
 
 ```bash
 ANSIBLE_INVENTORY_PATH=/path/to/ansible_hosts.yml
+
+# Ansible inventory group name (default: PiHole)
+# Change this if you use a different group name in your ansible_hosts.yml
+PIHOLE_ANSIBLE_GROUP=PiHole
+
 # API keys still required in .env:
 PIHOLE_API_KEY_SERVER1=your-api-key-here
 PIHOLE_API_KEY_SERVER2=your-api-key-here


### PR DESCRIPTION
Fixes #9

- Added DOCKER_ANSIBLE_GROUP environment variable to .env.example (default: docker_hosts)
- Added PODMAN_ANSIBLE_GROUP environment variable to .env.example (default: podman_hosts)
- Added PIHOLE_ANSIBLE_GROUP environment variable to .env.example (default: PiHole)
- Documented Docker/Podman inventory group configuration in README.md
- Documented Pi-hole inventory group configuration in README.md

This completes the documentation for configurable Ansible inventory groups following the pattern established in PR #6 for Ollama. Users with different naming conventions can now easily configure group names without modifying code.

Note: The code implementation was already completed in commits 7ede128 and 281cb11. This commit adds the missing documentation to .env.example and README.md.