### PR TITLE
docs: Add Docker Hub references to documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,18 @@
 
 ## Project Overview
 
-**Repository:** <https://github.com/bjeans/homelab-mcp>  
-**Version:** 2.0.0 (Released: 2025-10-30)  
-**License:** MIT  
+**Repository:** <https://github.com/bjeans/homelab-mcp>
+**Docker Hub:** <https://hub.docker.com/r/bjeans/homelab-mcp>
+**Version:** 2.0.0 (Released: 2025-10-30)
+**License:** MIT
 **Purpose:** Open-source MCP servers for homelab infrastructure management through Claude Desktop
 
 This project provides real-time monitoring and control of homelab infrastructure through 7 specialized MCP servers, including Docker/Podman containers, Ollama AI models, Pi-hole DNS, Unifi networks, UPS monitoring, and Ansible inventory management via the Model Context Protocol.
+
+**Deployment Options:**
+- Native Python installation (recommended for development)
+- Docker container from Docker Hub: `bjeans/homelab-mcp:latest` (recommended for production)
+- Docker build from source (for customization)
 
 ## Core Philosophy
 
@@ -50,12 +56,15 @@ homelab-mcp/
 │   ├── CI_CD_CHECKS.md                # CI/CD automation docs
 │   └── LICENSE                        # MIT License
 │
+├── Docker Deployment
+│   ├── Dockerfile                     # Container build config
+│   ├── docker-compose.yml             # Container orchestration (uses bjeans/homelab-mcp:latest)
+│   ├── docker-entrypoint.sh           # Docker container startup
+│   └── Published at: <https://hub.docker.com/r/bjeans/homelab-mcp>
+│
 ├── Utilities & Tools
 │   ├── mcp_registry_inspector.py      # MCP file management
 │   ├── unifi_exporter.py              # Unifi data export utility
-│   ├── docker-entrypoint.sh           # Docker container startup
-│   ├── Dockerfile                     # Container build config
-│   ├── docker-compose.yml             # Container orchestration
 │   ├── requirements.txt               # Python dependencies
 │   └── .gitignore                     # Git ignore rules
 │
@@ -77,20 +86,20 @@ All servers follow this unified architecture supporting both **standalone** and 
 ```python
 class UpsMCPServer:
     """Service-specific MCP server with shared inventory support"""
-    
+
     def __init__(self, ansible_inventory=None):
         """Initialize with optional pre-loaded inventory (for unified mode)
-        
+
         Args:
             ansible_inventory: Pre-loaded inventory dict from unified server
                              If None, will load from file at runtime
         """
         self.ansible_inventory = ansible_inventory
         self.inventory_data = None
-    
+
     async def list_tools(self) -> list[types.Tool]:
         """Return tools with SERVICE_ prefix (e.g., ups_get_status)
-        
+
         Prefix ensures no collisions when combined in unified server
         """
         return [
@@ -101,7 +110,7 @@ class UpsMCPServer:
             ),
             # ... more tools
         ]
-    
+
     async def handle_tool(self, tool_name: str, arguments: dict) -> list[types.TextContent]:
         """Route tool calls to shared implementation
         
@@ -868,6 +877,7 @@ This allows Claude to:
 ## Links and Resources
 
 - **Repository:** <https://github.com/bjeans/homelab-mcp>
+- **Docker Hub:** <https://hub.docker.com/r/bjeans/homelab-mcp>
 - **Issues:** <https://github.com/bjeans/homelab-mcp/issues>
 - **Discussions:** <https://github.com/bjeans/homelab-mcp/discussions>
 - **Security:** <https://github.com/bjeans/homelab-mcp/security/advisories>
@@ -883,6 +893,11 @@ This allows Claude to:
 cp .env.example .env                          # Create config file
 cp ansible_hosts.example.yml ansible_hosts.yml # Create Ansible inventory
 python install_git_hook.py                    # Install pre-push security checks
+
+# Docker deployment (production)
+docker pull bjeans/homelab-mcp:latest         # Pull pre-built image from Docker Hub
+docker-compose up -d                          # Run with Docker Compose
+docker build -t homelab-mcp:latest .          # Or build from source
 
 # Development
 python pre_publish_check.py                   # Run security checks before commit

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ After setting up the MCP servers, **create your personalized project instruction
 **What's included:**
 
 - Detailed MCP server capabilities and usage patterns
-- Infrastructure overview and monitoring capabilities  
+- Infrastructure overview and monitoring capabilities
 - Specific commands and tools available for each service
 - Troubleshooting and development guidance
 
@@ -308,17 +308,15 @@ Separate entry for each server:
 
 Run the MCP servers in Docker containers for easier distribution, isolation, and production deployment.
 
+**Docker Hub:** [bjeans/homelab-mcp](https://hub.docker.com/r/bjeans/homelab-mcp)
+
 ### Quick Start with Docker (Unified Mode - Recommended)
 
 **All servers in one container using unified mode:**
 
 ```bash
-# Clone and navigate to repository
-git clone https://github.com/bjeans/homelab-mcp
-cd homelab-mcp
-
-# Build the image
-docker build -t homelab-mcp:latest .
+# Pull the pre-built image from Docker Hub (recommended)
+docker pull bjeans/homelab-mcp:latest
 
 # Run with Docker Compose (recommended for production)
 docker-compose up -d
@@ -328,7 +326,18 @@ docker run -d \
   --name homelab-mcp \
   --network host \
   -v $(pwd)/ansible_hosts.yml:/config/ansible_hosts.yml:ro \
-  homelab-mcp:latest
+  bjeans/homelab-mcp:latest
+```
+
+**Building from source (optional):**
+
+```bash
+# Clone and navigate to repository
+git clone https://github.com/bjeans/homelab-mcp
+cd homelab-mcp
+
+# Build the image locally
+docker build -t homelab-mcp:latest .
 ```
 
 ### Docker Features
@@ -354,7 +363,7 @@ docker run -d \
   --name homelab-mcp \
   --network host \
   -v $(pwd)/ansible_hosts.yml:/config/ansible_hosts.yml:ro \
-  homelab-mcp:latest
+  bjeans/homelab-mcp:latest
 ```
 
 **Method 2: Environment Variables (Marketplace Ready)**
@@ -366,7 +375,7 @@ docker run -d \
   -e DOCKER_SERVER1_ENDPOINT=192.168.1.100:2375 \
   -e DOCKER_SERVER1_NAME=Local-Docker \
   -e OLLAMA_SERVER1_ENDPOINT=192.168.1.100:11434 \
-  homelab-mcp:latest
+  bjeans/homelab-mcp:latest
 ```
 
 ### Legacy Mode: Individual Servers (Docker)
@@ -379,7 +388,7 @@ docker run -d \
   --network host \
   -e ENABLED_SERVERS=docker \
   -v $(pwd)/ansible_hosts.yml:/config/ansible_hosts.yml:ro \
-  homelab-mcp:latest
+  bjeans/homelab-mcp:latest
 ```
 
 ### Available Servers
@@ -456,12 +465,12 @@ See [DOCKER.md](DOCKER.md) for comprehensive Docker deployment guide including:
 docker run --rm --network host \
     -e DOCKER_SERVER1_ENDPOINT=localhost:2375 \
     -e OLLAMA_SERVER1_ENDPOINT=localhost:11434 \
-    homelab-mcp:latest
+    bjeans/homelab-mcp:latest
 
 # Test Individual Server (legacy)
 docker run --rm --network host \
     -e ENABLED_SERVERS=ping \
-    homelab-mcp:latest
+    bjeans/homelab-mcp:latest
 ```
 
 **Docker Compose testing:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 services:
   # Unified Homelab MCP Server (RECOMMENDED - All services in one)
   homelab-mcp:
-    build: .
+    image: bjeans/homelab-mcp:latest
+    # Uncomment to build from source instead of using Docker Hub image:
+    # build: .
     container_name: homelab-mcp
     environment:
       # Leave ENABLED_SERVERS unset to use unified mode (default)
@@ -42,7 +44,9 @@ services:
 
   # Legacy mode: Individual servers (uncomment if needed)
   # homelab-mcp-docker:
-  #   build: .
+  #   image: bjeans/homelab-mcp:latest
+  #   # Uncomment to build from source instead of using Docker Hub image:
+  #   # build: .
   #   container_name: homelab-mcp-docker
   #   environment:
   #     - ENABLED_SERVERS=docker
@@ -55,7 +59,9 @@ services:
   #   tty: true
 
   # homelab-mcp-ping:
-  #   build: .
+  #   image: bjeans/homelab-mcp:latest
+  #   # Uncomment to build from source instead of using Docker Hub image:
+  #   # build: .
   #   container_name: homelab-mcp-ping
   #   environment:
   #     - ENABLED_SERVERS=ping


### PR DESCRIPTION
## Summary

Updates documentation to reflect the published Docker image at https://hub.docker.com/r/bjeans/homelab-mcp

## Changes

### README.md
- ✅ Added Docker Hub link prominently in Docker Deployment section
- ✅ Updated quick start to use `docker pull bjeans/homelab-mcp:latest` as primary method
- ✅ Moved local build instructions to optional "Building from source" section
- ✅ Updated all docker run examples to use published image
- ✅ Removed trailing whitespace (line 81)

### docker-compose.yml
- ✅ Changed from `build: .` to `image: bjeans/homelab-mcp:latest`
- ✅ Added commented-out `build: .` option for local builds
- ✅ Applied changes to unified and legacy mode service definitions

### CLAUDE.md
- ✅ Added Docker Hub link to Project Overview section
- ✅ Listed deployment options (native Python, Docker Hub, build from source)
- ✅ Reorganized project structure to highlight Docker deployment
- ✅ Added Docker Hub link to Links and Resources section
- ✅ Updated Quick Commands Reference with docker pull command
- ✅ Fixed URL format inconsistency (line 63 - added angle brackets)
- ✅ Removed trailing whitespace from code examples

## Documentation Quality Review

All changes were reviewed by the documentation-quality-reviewer agent:
- ✅ All Docker image references consistently use `bjeans/homelab-mcp:latest`
- ✅ Version 2.0.0 consistent across all documentation
- ✅ All Docker Hub links valid and pointing to correct repository
- ✅ No security issues, credentials, or sensitive data found
- ✅ All internal file references validated

## Testing

- ✅ Security pre-push hook passed all checks
- ✅ No real infrastructure details exposed
- ✅ All .gitignore rules working correctly

## Related

- Related to #24 (automated Docker builds tracking issue)
- Docker Hub repository: https://hub.docker.com/r/bjeans/homelab-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)