### PR TITLE
docs: add Docker integration checklist to prevent deployment issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,8 +422,16 @@ COPY --chown=mcpuser:mcpuser minio_mcp_server.py .
 docker build -t homelab-mcp:test .
 
 # Verify new file is in the image
+# NOTE: The following command will start the MCP server and hang indefinitely waiting for stdio input.
+# This is expected behavior for MCP servers. If you see the process hang, it means the file was found and started successfully.
+# Use Ctrl+C to exit.
 docker run --rm homelab-mcp:test python minio_mcp_server.py
 
+# Alternatively, you can use a timeout to run the server briefly:
+timeout 2 docker run --rm homelab-mcp:test python minio_mcp_server.py || [ $? -eq 124 ]
+
+# Or simply check that the file can be imported:
+docker run --rm homelab-mcp:test python -c "import minio_mcp_server"
 # If imports fail, you missed a dependency file!
 ```
 
@@ -480,7 +488,7 @@ python minio_mcp_server.py
 #### Docker Update Workflow
 
 ```bash
-# 1. Add file to Dockerfile (alphabetically ordered)
+# 1. Add file to Dockerfile in an organized manner
 COPY --chown=mcpuser:mcpuser your_new_file.py .
 
 # 2. Test build locally
@@ -490,7 +498,15 @@ docker build -t homelab-mcp:test .
 docker run --rm homelab-mcp:test python -c "import your_new_module"
 
 # 4. Test the unified server starts
+# This command will start the server and hang indefinitely waiting for MCP stdio input (this is expected behavior).
+# You should see no errors, and can use Ctrl+C to exit.
 docker run --rm homelab-mcp:test python homelab_unified_mcp.py
+
+# Alternatively, you can use a timeout to automatically exit after a few seconds:
+timeout 2 docker run --rm homelab-mcp:test python homelab_unified_mcp.py || [ $? -eq 124 ]
+
+# Or, for a quick import check (does not start the server):
+docker run --rm homelab-mcp:test bash -c "python -c 'import homelab_unified_mcp'"
 ```
 
 #### Common Docker Mistakes


### PR DESCRIPTION
## Summary

Adds comprehensive Docker integration checklist to `CLAUDE.md` to prevent deployment failures when new Python files are created but not added to the Dockerfile.

This addresses the root cause of the issue encountered in PR #32, where `mcp_error_handler.py` was created but omitted from the Dockerfile, causing import failures in containerized deployments while working fine locally.

## Changes

- **Step 7b**: Added "Update Dockerfile" step to the "Creating a New Server" workflow with verification commands
- **Docker Integration Checklist**: New section with clear guidelines on when/how to update Dockerfile
- **Common Docker Mistakes**: Documents the PR #32 example and other common pitfalls
- **Security Checklist**: Added 3 Docker-related items to pre-commit checklist

## Key Guidelines Added

**When to update Dockerfile:**
- ✅ New MCP server files
- ✅ New shared modules (like `mcp_error_handler.py`, `ansible_config_manager.py`)
- ✅ Any `.py` file imported by runtime code
- ❌ Test files, helpers, examples, documentation

**Verification workflow:**
```bash
docker build -t homelab-mcp:test .
docker run --rm homelab-mcp:test python -c "import your_new_module"
docker run --rm homelab-mcp:test python homelab_unified_mcp.py
```

## Impact

This documentation change will help prevent future deployment issues by making Docker integration a mandatory part of the development workflow, not an afterthought.

🤖 Generated with [Claude Code](https://claude.com/claude-code)