### PR TITLE
fix: Replace _tool_manager._tools with mount() for FastMCP 3.x compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,13 +186,13 @@ All tools should include `ToolAnnotations` to provide behavioral hints to MCP cl
 
 #### 4. Unified Server Composition
 
-The unified server uses **FastMCP's native composition** - no manual wrapper functions needed!
+The unified server uses **FastMCP's `mount()` API** (FastMCP 3.x) - no manual wrapper functions needed!
 
 ```python
 #!/usr/bin/env python3
 """
-Homelab Unified MCP Server v3.0 (FastMCP)
-Combines all 7 sub-servers using FastMCP's native composition
+Homelab Unified MCP Server v3.1 (FastMCP)
+Combines all 7 sub-servers using FastMCP's native mount() composition
 """
 
 from fastmcp import FastMCP
@@ -207,14 +207,17 @@ os.environ["MCP_UNIFIED_MODE"] = "1"
 
 
 def compose_servers():
-    """Compose all sub-servers into unified server"""
+    """Compose all sub-servers into unified server using FastMCP's native pattern
+
+    FastMCP's mount() method merges tools from each sub-server without prefixing,
+    preserving flat tool names (e.g., 'docker_list_containers', not 'docker/docker_list_containers').
+    """
     # Import sub-servers (each has its own mcp instance with decorated tools)
     import ansible_mcp_server
     import docker_mcp_podman
     import ups_mcp_server
     # ... etc
 
-    # Collect sub-servers
     subservers = {
         'ansible': ansible_mcp_server.mcp,
         'docker': docker_mcp_podman.mcp,
@@ -222,12 +225,11 @@ def compose_servers():
         # ... etc
     }
 
-    # Compose tools from all sub-servers
+    # mount() without a prefix merges tools flat, preserving original tool names.
+    # Do NOT pass prefix=server_name or tools will be namespaced (e.g. 'ansible/ansible_list_hosts').
     for server_name, server_mcp in subservers.items():
-        if hasattr(server_mcp, '_tool_manager'):
-            tools = server_mcp._tool_manager._tools
-            for tool_name, tool in tools.items():
-                mcp.add_tool(tool)
+        mcp.mount(server_mcp)
+        logger.info(f"Mounted {server_name} server")
 
     logger.info("All sub-servers composed successfully")
 
@@ -242,6 +244,7 @@ compose_servers()
 - ✅ FastMCP handles tool registration automatically
 - ✅ Each sub-server works standalone or in unified mode
 - ✅ Single source of truth for each tool
+- ✅ Uses public `mount()` API — no reliance on private internals
 
 ### Why FastMCP?
 

--- a/homelab_unified_mcp.py
+++ b/homelab_unified_mcp.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Homelab Unified MCP Server v2.3 (FastMCP)
+Homelab Unified MCP Server v3.1 (FastMCP)
 Unified server that combines all homelab MCP servers into a single entry point
-Uses FastMCP's native composition pattern - no manual wrappers needed
+Uses FastMCP's native mount() composition pattern - no manual wrappers needed
 """
 
 import logging
@@ -74,19 +74,11 @@ def compose_servers():
         'ups': ups_mcp_server.mcp,
     }
 
-    # Compose tools from all sub-servers
-    # FastMCP's FunctionTool objects can be directly added to another FastMCP instance
+    # Compose tools from all sub-servers using FastMCP 3.x mount()
+    # mount() without a prefix merges tools flat, preserving original tool names
     for server_name, server_mcp in subservers.items():
-        # Access the internal tools dict (FastMCP stores tools in _tool_manager._tools)
-        # Each tool is already properly registered with its prefix from the sub-server
-        if hasattr(server_mcp, '_tool_manager') and hasattr(server_mcp._tool_manager, '_tools'):
-            tools = server_mcp._tool_manager._tools
-            for tool_name, tool in tools.items():
-                # Add tool directly - FastMCP handles the registration
-                mcp.add_tool(tool)
-            logger.info(f"Added {len(tools)} {server_name} tools")
-        else:
-            logger.warning(f"Could not find tools in {server_name} server")
+        mcp.mount(server_mcp)
+        logger.info(f"Mounted {server_name} server")
 
     logger.info("All sub-servers composed successfully")
 

--- a/homelab_unified_mcp.py
+++ b/homelab_unified_mcp.py
@@ -49,7 +49,8 @@ def compose_servers():
     """Compose all sub-servers into unified server using FastMCP's native pattern
 
     This function runs at module import time to register all tools from sub-servers.
-    FastMCP's add_tool() method properly handles tool registration without manual wrappers.
+    FastMCP's mount() method merges tools from each sub-server without prefixing,
+    preserving flat tool names (e.g., 'docker_list_containers', not 'docker/docker_list_containers').
     """
     # Import sub-servers (they each have their own mcp instance with decorated tools)
     import ansible_mcp_server

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # MCP Server Framework
 mcp>=1.0.0
-fastmcp>=2.11.0
+fastmcp>=3.0.0,<4.0.0
 
 # Ansible configuration management (official library)
 # Falls back to manual YAML parsing on unsupported systems (e.g., Windows)


### PR DESCRIPTION
## Summary

- Replaces broken `_tool_manager._tools` private API with FastMCP 3.x `mount()` for server composition
- Pins `fastmcp>=3.0.0,<4.0.0` to prevent future surprise major version bumps

Fixes #69

## Context

FastMCP upgraded from 2.x to 3.x in Docker builds (unpinned `>=2.11.0`), removing the `_tool_manager` internal attribute. This caused the unified server to register **zero tools** — all 7 sub-servers silently failed the `hasattr` check.

## Test plan

- [ ] Build Docker image and verify `tools/list` returns all 39 tools (not empty `[]`)
- [ ] Verify tool names remain flat (e.g. `docker_list_containers`, not namespaced)
- [ ] Verify each sub-server still works standalone
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)